### PR TITLE
Add draft schedule

### DIFF
--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,4 +3,61 @@ title: Workshop Schedule
 nav_title: Schedule
 ---
 
-The schedule is forthcoming, please stay tuned!
+Below is the planned schedule for the June 13-15, 2023 Data Lab "Introduction to single-cell RNA-seq" training workshop.
+
+| Time      | Topic                                                            |
+|------------------|------------------------------------------------------|
+| **Day 1** | **2023-06-13**                                                   |
+| 9:00 AM   | Welcome, Introductions and Getting Started |
+| 10:00 AM  | Introduction to R and RStudio |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-r-tidyverse/01-intro_to_base_R.nb.html)  |
+| 11:15 AM  | *Coffee break*                                                   |
+| 11:30 AM  | Introduction to `ggplot2`  |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-r-tidyverse/02-intro_to_ggplot2.nb.html)  |
+| 12:30 PM  | *Lunch*                                                          |
+| 1:30 PM   | Introduction to `tidyverse` |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-r-tidyverse/03-intro_to_tidyverse.nb.html) |
+| 2:30 PM   | *Coffee break*                                                   |
+| 2:45 PM   | Exercises and Questions   |
+|             | [Exercise: Introduction to base R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_01-intro_to_base_R.Rmd)  |
+|             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)  |
+|             | [Exercise: Introduction to the `tidyverse`, Part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse//exercise_03a-intro_to_tidyverse.Rmd) |
+|             | [Exercise: Introduction to the `tidyverse`, Part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse//exercise_03b-intro_to_tidyverse.Rmd) |
+| 3:30 PM   | scRNA-seq quantification |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) |
+| 5:00 PM   | *Adjourn for the day*                                            |
+|           |                                                                  |
+| **Day 2** | **2023-06-14**                                                   |
+| 8:30 AM   | Breakfast and coffee                                             |
+| 9:00 AM   | Questions and Review                                             |
+| 9:20 AM   | scRNA-seq quality control and filtering                          |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html) |
+| 10:45 AM  | *Coffee break*                                                   |
+| 11:00 AM  | Normalizing scRNA-seq data                                       |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) |
+| 12:15 PM  | *Lunch*                                                          |
+| 1:15 PM   | Dimension Reduction in scRNA-seq                                 |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) |
+| 2:30 PM   | *Coffee break*                                                   |
+| 2:45 PM   | Clustering and marker gene identification                        |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html) |
+| 3:45 PM   | Exercises, Questions, and Independent Projects                   |
+|           | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd)  |
+|           | [Exercise: Dimension reduction and clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd)  |
+|           | [Resources](resources-for-consultation-sessions.md)              |
+| 5:00 PM   | *Adjourn for the day*                                            |
+| 6:30 PM   | Workshop dinner; Location TBA                                    |
+|           |                                                                  |
+| **Day 3** | **2023-06-15**                                                   |
+| 9:00 AM   | Questions and Review                                             |
+| 9:30 AM   | Cell type annotation, Part 1                                     |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.nb.html) |
+| 11:00 AM  | *Coffee break*                                                   |
+| 11:15 AM  | Cell type annotation, Part 2 _(Same completed notebook)_         |
+| 12:30 PM  | *Lunch*                                                          |
+| 1:30 PM   | Exercises, Questions, and Independent Projects                   |
+|           | [Exercise: Cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_03-celltype.Rmd)  |
+|           | [Resources](resources-for-consultation-sessions.md)              |
+| 2:45 PM   | Learn about Data Lab scRNA-seq projects                          |
+| 3:00 PM   | Participant Presentations!                                       |
+| 4:00 PM   | *Adjourn*                                                        |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -36,7 +36,7 @@ Below is the planned schedule for the June 13-15, 2023 Data Lab "Introduction to
 | 11:00 AM  | Normalizing scRNA-seq data                                       |
 |           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) |
 | 12:15 PM  | *Lunch*                                                          |
-| 1:15 PM   | Dimension Reduction in scRNA-seq                                 |
+| 1:15 PM   | Dimension reduction in scRNA-seq                                 |
 |           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) |
 | 2:30 PM   | *Coffee break*                                                   |
 | 2:45 PM   | Clustering and marker gene identification                        |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -10,13 +10,13 @@ Below is the planned schedule for the June 13-15, 2023 Data Lab "Introduction to
 | **Day 1** | **2023-06-13**                                                   |
 | 9:00 AM   | Welcome, Introductions and Getting Started |
 | 10:00 AM  | Introduction to R and RStudio |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-r-tidyverse/01-intro_to_base_R.nb.html)  |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html)  |
 | 11:15 AM  | *Coffee break*                                                   |
 | 11:30 AM  | Introduction to `ggplot2`  |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-r-tidyverse/02-intro_to_ggplot2.nb.html)  |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html)  |
 | 12:30 PM  | *Lunch*                                                          |
 | 1:30 PM   | Introduction to `tidyverse` |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-r-tidyverse/03-intro_to_tidyverse.nb.html) |
+|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) |
 | 2:30 PM   | *Coffee break*                                                   |
 | 2:45 PM   | Exercises and Questions   |
 |             | [Exercise: Introduction to base R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_01-intro_to_base_R.Rmd)  |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -5,42 +5,36 @@ nav_title: Schedule
 
 Below is the planned schedule for the June 13-15, 2023 Data Lab "Introduction to single-cell RNA-seq" training workshop.
 
+All notebook links contain solutions which we will work through together during the workshop.
+
 | Time      | Topic                                                            |
 |------------------|------------------------------------------------------|
 | **Day 1** | **2023-06-13**                                                   |
 | 9:00 AM   | Welcome, Introductions and Getting Started |
-| 10:00 AM  | Introduction to R and RStudio |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html)  |
+| 10:00 AM  | [Notebook: Introduction to R and RStudio](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) |
 | 11:15 AM  | *Coffee break*                                                   |
-| 11:30 AM  | Introduction to `ggplot2`  |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html)  |
+| 11:30 AM  | [Notebook: Introduction to `ggplot2`](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html)  |
 | 12:30 PM  | *Lunch*                                                          |
-| 1:30 PM   | Introduction to `tidyverse` |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) |
+| 1:30 PM   | [Notebook: Introduction to `tidyverse`](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) |
 | 2:30 PM   | *Coffee break*                                                   |
 | 2:45 PM   | Exercises and Questions   |
 |             | [Exercise: Introduction to base R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_01-intro_to_base_R.Rmd)  |
 |             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)  |
 |             | [Exercise: Introduction to the `tidyverse`, Part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse//exercise_03a-intro_to_tidyverse.Rmd) |
 |             | [Exercise: Introduction to the `tidyverse`, Part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse//exercise_03b-intro_to_tidyverse.Rmd) |
-| 3:30 PM   | scRNA-seq quantification |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) |
+| 3:30 PM   | [Notebook: scRNA-seq quantification](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) |
 | 5:00 PM   | *Adjourn for the day*                                            |
 |           |                                                                  |
 | **Day 2** | **2023-06-14**                                                   |
 | 8:30 AM   | Breakfast and coffee                                             |
 | 9:00 AM   | Questions and Review                                             |
-| 9:20 AM   | scRNA-seq quality control and filtering                          |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html) |
+| 9:20 AM   | [Notebook: scRNA-seq quality control and filtering](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html) |
 | 10:45 AM  | *Coffee break*                                                   |
-| 11:00 AM  | Normalizing scRNA-seq data                                       |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) |
+| 11:00 AM  | [Notebook: Normalizing scRNA-seq data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) |                                       |
 | 12:15 PM  | *Lunch*                                                          |
-| 1:15 PM   | Dimension reduction in scRNA-seq                                 |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) |
+| 1:15 PM   | [Notebook: Dimension reduction with scRNA-seq data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html)                                 |
 | 2:30 PM   | *Coffee break*                                                   |
-| 2:45 PM   | Clustering and marker gene identification                        |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html) |
+| 2:45 PM   | [Notebook: Clustering and marker gene identification](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html)                        |
 | 3:45 PM   | Exercises, Questions, and Independent Projects                   |
 |           | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd)  |
 |           | [Exercise: Dimension reduction and clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd)  |
@@ -50,8 +44,7 @@ Below is the planned schedule for the June 13-15, 2023 Data Lab "Introduction to
 |           |                                                                  |
 | **Day 3** | **2023-06-15**                                                   |
 | 9:00 AM   | Questions and Review                                             |
-| 9:30 AM   | Cell type annotation, Part 1                                     |
-|           | [Completed instruction notebook](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.nb.html) |
+| 9:30 AM   | [Notebook: Cell type annotation](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.nb.html), Part 1                                     |
 | 11:00 AM  | *Coffee break*                                                   |
 | 11:15 AM  | Cell type annotation, Part 2 _(Same completed notebook)_         |
 | 12:30 PM  | *Lunch*                                                          |


### PR DESCRIPTION
_**Stacked on #12**_

This PR adds the draft schedule! I wanted to include the phrase "completed instruction notebook" to make it extra clear that these links are "answers," not just the same notebook that they are working on. But now I'm wondering if it's clear that those links are referring the given lesson, or has this become too ambiguous? It's clear to me, but I also wrote it and am rather biased......

For reference, here is our internal schedule: https://github.com/AlexsLemonade/training-admin/blob/788b1d8912a0947e7f511ae1fae13a2970a8c30f/internal-schedules/2023-june-internal-schedule.md